### PR TITLE
fix(meetups): fixed broken meetup and planet dates

### DIFF
--- a/contents/conferences/chtijs-1.md
+++ b/contents/conferences/chtijs-1.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #1'
 description:
   'Découvrez le contenu du ChtiJS n°1 avec la présentation de Nicolas Froidure
   sur le streaming HTTP et les promises.'
-published: '2013-04-04T12:00:00Z'
+date: '2013-04-04T12:00:00Z'
 keywords:
   - HTTP
   - streaming

--- a/contents/conferences/chtijs-10.md
+++ b/contents/conferences/chtijs-10.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #10'
 description:
   'Découvrez le contenu du ChtiJS n°10 avec les présentations de Nicolas
   Froidure, François Lecroart et Tom Panier.'
-published: '2015-02-05T19:00:00Z'
+date: '2015-02-05T19:00:00Z'
 keywords:
   - ReactJS
   - MeteorJS

--- a/contents/conferences/chtijs-11.md
+++ b/contents/conferences/chtijs-11.md
@@ -1,9 +1,9 @@
 ---
 title: 'ChtiJS #11'
 description:
-  "Découvrez le contenu du ChtiJS n°11 avec les présentations d'Emmanuel Demey,
-  de Johnathan Meunier et de Xavier Van de Woestyne."
-published: '2015-03-19T19:00:00Z'
+  "Découvrez le contenu du ChtiJS n°11 avec les présentations d'Emmanuel Demey, 
+  Johnathan Meunier et Xavier Van de Woestyne."
+date: '2015-03-19T19:00:00Z'
 keywords:
   - ReactJS
   - MeteorJS

--- a/contents/conferences/chtijs-12.md
+++ b/contents/conferences/chtijs-12.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #12'
 description:
   "Découvrez le contenu du ChtiJS n°12 avec les présentations d'Hubert
   Sablonnière et de Thomas Magdziarz."
-published: '2015-04-23T19:00:00Z'
+date: '2015-04-23T19:00:00Z'
 keywords:
   - ServiceWorkers
   - Espruino

--- a/contents/conferences/chtijs-13.md
+++ b/contents/conferences/chtijs-13.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #13'
 description:
   'Découvrez le contenu du ChtiJS n°13 avec les présentations de Nicolas
   Froidure, Tom Panier et Rémi Grumeau.'
-published: '2015-07-02T19:00:00Z'
+date: '2015-07-02T19:00:00Z'
 keywords:
   - ServiceWorkers
   - Espruino

--- a/contents/conferences/chtijs-14.md
+++ b/contents/conferences/chtijs-14.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #14'
 description:
   'Découvrez le contenu du ChtiJS n°14 avec les présentations de Mathieu
   Acthernoene et de Adrien G.'
-published: '2015-10-01T19:00:00Z'
+date: '2015-10-01T19:00:00Z'
 keywords:
   - Electron
   - ES6

--- a/contents/conferences/chtijs-15.md
+++ b/contents/conferences/chtijs-15.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #15'
 description:
   'Découvrez le contenu du ChtiJS n°15 avec les présentations de Nicolas
   Froidure, Vincent Billey et Mathieu Acthernoene.'
-published: '2016-02-25T19:00:00Z'
+date: '2016-02-25T19:00:00Z'
 keywords:
   - NodeJS
   - Micro service

--- a/contents/conferences/chtijs-16.md
+++ b/contents/conferences/chtijs-16.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #16'
 description:
   'Découvrez le contenu du ChtiJS n°16 avec les présentations de Jean-Baptiste
   Pionnier et Mathieu Acthernoene.'
-published: '2016-06-30T19:00:00Z'
+date: '2016-06-30T19:00:00Z'
 keywords:
   - NodeJS
   - React Native

--- a/contents/conferences/chtijs-17.md
+++ b/contents/conferences/chtijs-17.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #17'
 description:
   'Découvrez le contenu du ChtiJS n°17 avec les présentations de Nicolas
   Froidure, David Leuliette et Thomas Balouet.'
-published: '2017-02-09T19:00:00Z'
+date: '2017-02-09T19:00:00Z'
 keywords:
   - NodeJS
   - VR

--- a/contents/conferences/chtijs-18.md
+++ b/contents/conferences/chtijs-18.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #18'
 description:
   'Découvrez le contenu du ChtiJS n°18 avec les présentations de Emmanuel Demey,
 Kévin Dunglas et Nicolas Pennec.'
-published: '2017-06-01T19:00:00Z'
+date: '2017-06-01T19:00:00Z'
 keywords:
   - VueJS
   - Symfony

--- a/contents/conferences/chtijs-19.md
+++ b/contents/conferences/chtijs-19.md
@@ -2,7 +2,7 @@
 title: 'ChtiJS #19'
 description:
   'Découvrez le contenu du ChtiJS n°19 avec les présentations de Xavier Coiffard et Florent Giraud.'
-published: '2018-10-04T19:00:00Z'
+date: '2018-10-04T19:00:00Z'
 keywords:
   - NodeJS
   - TypeScript

--- a/contents/conferences/chtijs-2.md
+++ b/contents/conferences/chtijs-2.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #2'
 description:
   "Découvrez le contenu du ChtiJS n°2 avec la présentation de Paul d'Hubert sur
   les concepts d'AngularJS."
-published: '2013-04-26T12:00:00Z'
+date: '2013-04-26T12:00:00Z'
 keywords:
   - AngularJS
 lang: fr

--- a/contents/conferences/chtijs-20.md
+++ b/contents/conferences/chtijs-20.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #20'
 description:
   'Découvrez le contenu du ChtiJS n°20 avec les présentations de Xavier Van de
   Woestyne, Cyril Lakech et Laurent Thiebault.'
-published: '2018-11-14T19:00:00Z'
+date: '2018-11-14T19:00:00Z'
 keywords:
   - NodeJS
   - Types

--- a/contents/conferences/chtijs-21.md
+++ b/contents/conferences/chtijs-21.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #21'
 description:
   'Découvrez le contenu du ChtiJS n°21 avec les présentations de Nicolas
   Froidure et Florent Giraud .'
-published: '2019-01-24T19:00:00Z'
+date: '2019-01-24T19:00:00Z'
 keywords:
   - NodeJS
   - VueStyleguidist

--- a/contents/conferences/chtijs-22.md
+++ b/contents/conferences/chtijs-22.md
@@ -2,7 +2,7 @@
 title: 'ChtiJS #22'
 description:
   'Découvrez le contenu du ChtiJS n°22 avec les présentations de Nicolas Delperdange et François Lecroart.'
-published: '2019-03-28T19:00:00Z'
+date: '2019-03-28T19:00:00Z'
 keywords:
   - Git
   - Husky

--- a/contents/conferences/chtijs-23.md
+++ b/contents/conferences/chtijs-23.md
@@ -2,7 +2,7 @@
 title: 'ChtiJS #23'
 description:
   'Découvrez le contenu du ChtiJS n°23 avec les présentations de Julien Sadaoui, Hippolyte Durix et le duo Thomas FERRO / Edouard CATTEZ.'
-published: '2019-06-04T19:00:00Z'
+date: '2019-06-04T19:00:00Z'
 keywords:
   - Git
   - Husky

--- a/contents/conferences/chtijs-24.md
+++ b/contents/conferences/chtijs-24.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #24'
 description:
   'Découvrez le contenu du ChtiJS n°24 avec les présentations de Mathys
   Visticot, Nicolas Froidure .'
-published: '2022-11-03T18:00:00Z'
+date: '2022-11-03T18:00:00Z'
 keywords:
   - NodeJS
   - ElasticSearch

--- a/contents/conferences/chtijs-3.md
+++ b/contents/conferences/chtijs-3.md
@@ -1,7 +1,7 @@
 ---
 title: "ChtiJS #3"
 description: "Découvrez le contenu du ChtiJS n°3 avec la présentation de Nicolas Froidure sur les promises et une table ronde sur la mise en production d'applications NodeJS."
-published: "2013-07-25T12:00:00Z"
+date: "2013-07-25T12:00:00Z"
 keywords:
   - promises
   - NodeJS
@@ -14,7 +14,7 @@ location: FR
 ## Programme
 
 Présentation de Nicolas Froidure
- ([@nfroidure](https://twitter.com/nfroidure)) sur sur les
+ ([@nfroidure](https://twitter.com/nfroidure)) sur les
  [promises](http://server.elitwork.com/presentations/promises.html#/intro),
  puis, table ronde et retours d'expérience sur la mise en production
  d'applications réalisées avec NodeJS.

--- a/contents/conferences/chtijs-4.md
+++ b/contents/conferences/chtijs-4.md
@@ -4,7 +4,7 @@ description:
   'Découvrez le contenu du ChtiJS n°4 avec les présentations de Jean-Baptiste
   Pionnier sur AngularJS, Rémi Grumeau sur Emy et David Loeuillete sur Pokémon
   Breakpoint.'
-published: '2013-09-19T12:00:00Z'
+date: '2013-09-19T12:00:00Z'
 keywords:
   - AngularJS
   - RWD

--- a/contents/conferences/chtijs-5.md
+++ b/contents/conferences/chtijs-5.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #5'
 description:
   'Découvrez le contenu du ChtiJS n°5 avec les présentations de Tom Panier,
   0gust1 et un échange sur les tests unitaires en JS.'
-published: '2013-10-31T12:00:00Z'
+date: '2013-10-31T12:00:00Z'
 keywords:
   - HTML5
   - GruntJS

--- a/contents/conferences/chtijs-6.md
+++ b/contents/conferences/chtijs-6.md
@@ -5,7 +5,7 @@ description:
   Pionnier sur la stack MEAN, de Nicolas Froidure sur le partage de code entre
   front et back, et le retour d'0gust1 et Tom Panier sur la création du site du
   groupe."
-published: '2013-12-12T12:00:00Z'
+date: '2013-12-12T12:00:00Z'
 keywords:
   - NodeJS
   - GruntJS

--- a/contents/conferences/chtijs-7.md
+++ b/contents/conferences/chtijs-7.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #7'
 description:
   'Découvrez le contenu du ChtiJS n°7 avec les présentations de Cyril Moreau et
   Rémi Grumeau.'
-published: '2014-02-20T19:00:00Z'
+date: '2014-02-20T19:00:00Z'
 keywords:
   - GolfJS
   - Frameworks

--- a/contents/conferences/chtijs-8.md
+++ b/contents/conferences/chtijs-8.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #8'
 description:
   'Découvrez le contenu du ChtiJS n°8 avec les présentations de Rémi Grumeau et
   François-Emmanuel Cortes.'
-published: '2014-07-24T19:00:00Z'
+date: '2014-07-24T19:00:00Z'
 keywords:
   - Firebase
   - RequireJS

--- a/contents/conferences/chtijs-9.md
+++ b/contents/conferences/chtijs-9.md
@@ -3,7 +3,7 @@ title: 'ChtiJS #9'
 description:
   'Découvrez le contenu du ChtiJS n°9 avec les présentations de Thomas Deconinck
   et Johnathan Meunier.'
-published: '2014-10-09T19:00:00Z'
+date: '2014-10-09T19:00:00Z'
 keywords:
   - Browserify
   - iBeacons

--- a/contents/conferences/embuscade-1.md
+++ b/contents/conferences/embuscade-1.md
@@ -3,7 +3,7 @@ title: 'EmbuscadeJS #1'
 description:
   'Découvrez le contenu de la première embuscade JavaScript de notre groupe avec
   la présentation de Thomas Parisot.'
-published: '2014-03-06T19:00:00Z'
+date: '2014-03-06T19:00:00Z'
 keywords:
   - README
   - driven

--- a/contents/pages/about.md
+++ b/contents/pages/about.md
@@ -3,13 +3,13 @@ title: Les habitudes de notre groupe
 description: Pour mieux comprendre ChtiJS, découvrez nos petites habitudes.
 shortTitle: Nos habitudes
 shortDesc: Découvrir nos habitudes
-lang: fr
-location: FR
 tags:
   - JavaScript
   - groupe
   - Nord
   - Pas-de-Calais
+lang: fr
+location: FR
 ---
 
 # Nos habitudes

--- a/src/pages/[id].tsx
+++ b/src/pages/[id].tsx
@@ -19,6 +19,8 @@ type Metadata = {
     href: string;
     alt: string;
   };
+  lang: string;
+  location: string
 };
 type Entry = {
   id: string;

--- a/src/pages/conferences/[id].tsx
+++ b/src/pages/conferences/[id].tsx
@@ -24,7 +24,7 @@ const BlogPost = ({ entry }: Props) => {
       <ContentBlock>
         {renderMarkdown({ index: 0 }, entry.content)}
         <Paragraph>
-          Publié le {new Date(entry.date).toLocaleString()}.
+          Publié le {new Date(entry.date).toLocaleDateString(undefined, { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}.
         </Paragraph>
         <div className="clear"></div>
         <Paragraph>

--- a/src/pages/conferences/index.tsx
+++ b/src/pages/conferences/index.tsx
@@ -27,6 +27,8 @@ export type Metadata = {
     url: string;
     alt: string;
   };
+  lang: string;
+  location: string
 };
 export type Entry = {
   id: string;
@@ -64,9 +66,7 @@ const BlogEntries = ({
   <Layout title={title} description={description}>
     <ContentBlock className="title">
       <Heading1 className="title">Résumés des rencontres</Heading1>
-      <Paragraph>
-        .
-      </Paragraph>
+      <Paragraph>.</Paragraph>
 
       <div className="entries">
         {entries.map((entry) => (
@@ -90,9 +90,9 @@ const BlogEntries = ({
               </Anchor>
             </Heading2>
             <Paragraph className="entry_description">
-              {entry.description}{' '}
-              <Anchor href={`/conferences/${entry.id}`}>Lire la suite</Anchor>
+              {entry.description}
             </Paragraph>
+            <Anchor href={`/conferences/${entry.id}`}>Lire la suite</Anchor>
             <div className="clear"></div>
           </div>
         ))}

--- a/src/pages/planete.tsx
+++ b/src/pages/planete.tsx
@@ -65,7 +65,7 @@ const Page = ({ entries }: Props) => {
                   {entry.entry.published ? (
                     <>
                       Publié le{' '}
-                      {entry.entry.published}
+                      {new Date(entry.entry.published).toLocaleDateString()}
                     </>
                   ) : (
                     ''


### PR DESCRIPTION
- Fixed **meetup** pages dates.
- Fixed **planet** articles dates.
- Transformed `toLocaleString()` to `toLocaleDateString()` because a React error was popping in.
- Changed `Lire la suite` so it appears as a **newLine**.