### PR TITLE
fix(README): updating README to fit the switch from X to Mastodon

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,6 @@ echo "GH_TOKEN=mysecrettoken\
 " >> .env.local
 ```
 
-Then create a [Twitter App](https://developer.twitter.com/):
-
-```sh
-echo "TWITTER_API_KEY=xxxxxx\
-TWITTER_API_KEY_SECRET=xxxxx\
-TWITTER_API_TOKEN=xxxxx\
-" >> .env.local
-```
-
 Then run the development server:
 
 ```bash


### PR DESCRIPTION
Now the account token is a constant, so you do not need to create or set a token.